### PR TITLE
added github, gitlab, bitbucket remotes.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,6 +19,15 @@
   <remote  name="XOSPD"
            fetch="https://github.com/"
            revision="cm-14.1" />
+  
+  <remote name="github_default"
+          fetch="https://github.com/" />
+
+  <remote name="gitlab"
+          fetch="https://gitlab.com/" />
+
+  <remote name="bitbucket"
+          fetch="https://bitbucket.org/" />
 
   <default revision="refs/heads/xosp-n-rebase"
            remote="github"


### PR DESCRIPTION
Deps fails on "github" if tree is at https://github.com, use "github_default" now.